### PR TITLE
Readme: Use bash instead of sh to run installer.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ brew install fwartner/tap/mac-cleanup
 ### Using curl
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/mac-cleanup/mac-cleanup-sh/main/installer.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mac-cleanup/mac-cleanup-sh/main/installer.sh)"
 ```
 
 ### Using wget
 
 ```bash
-sh -c "$(wget https://raw.githubusercontent.com/mac-cleanup/mac-cleanup-sh/main/installer.sh -O -)"
+bash -c "$(wget https://raw.githubusercontent.com/mac-cleanup/mac-cleanup-sh/main/installer.sh -O -)"
 ```
 
 ## Step by Step Install


### PR DESCRIPTION
The installer requires bash, as stated in the [shebang](https://github.com/mac-cleanup/mac-cleanup-sh/blob/e701c285675c7a7f63b042d8fc39c32dd9dac479/installer.sh#L1). As the variable name suggests, `BASH_SOURCE` is defined only in bash.
Fixes issue #74 _wget and curl fails with unbound variable `BASH_SOURCE`_.