### PR TITLE
fix: composer interaction

### DIFF
--- a/mac-cleanup
+++ b/mac-cleanup
@@ -184,7 +184,7 @@ fi
 
 if type "composer" &>/dev/null; then
 	msg 'Cleaning up composer...'
-	composer clearcache &>/dev/null
+	composer clearcache --no-interaction &>/dev/null
 fi
 
 # Deletes Steam caches, logs, and temp files


### PR DESCRIPTION
Without `--no-interaction`, the script can wait until a user response but stdout is redirect to `/dev/null`. 

```
$ composer clearcache
symfony/thanks contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/thanks" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```